### PR TITLE
Fix-bug: Corrected logic for finding the largest number in an array 

### DIFF
--- a/file4.js
+++ b/file4.js
@@ -1,13 +1,13 @@
 // file4.js
 
 function getLargestNumber(numbers) {
-    let max = numbers[1];  
-    for (let i = 1; i < numbers.length; i++) {
-        if (numbers[i] > max) {
-            max = numbers[i];
-        }
+  let max = numbers[0];
+  for (let i = 0; i < numbers.length; i++) {
+    if (numbers[i] > max) {
+      max = numbers[i];
     }
-    return max;
+  }
+  return max;
 }
 
 console.log("Largest number:", getLargestNumber([3, 5, 7, 2, 8])); // Expected output: 8, but will log: undefined or incorrect value


### PR DESCRIPTION
This commit addresses a bug in the `getLargestNumber` function where the initial maximum value was incorrectly set to the second element of the array (numbers[1]) instead of the first element `(numbers[0]`. Additionally, the loop started from `index 1`, skipping the first element.

To fix this, I updated the initial value of max to `numbers[0]` and changed the loop to start from `index 0`. This ensures that all elements in the array are considered when finding the maximum value.